### PR TITLE
add https support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,3 @@
-
 # MCP Connector
 
 **MCP Connector** is a lightweight server that can run and manage multiple Model Context Protocol (MCP) servers, specifically designed to integrate with [TypingMind](https://www.typingmind.com/mcp). It provides an easy way to run MCP servers on your local computer or a remote server, making it possible to connect your custom AI models or tools with TypingMind through a simple REST API.
@@ -16,6 +15,19 @@ npx @typingmind/mcp <auth-token>
 
 Keep this terminal window open while you use TypingMind.
 
+### HTTPS Support
+
+To enable HTTPS, set the following environment variables:
+
+```bash
+CERTFILE=./path/to/certificate.crt KEYFILE=./path/to/privatekey.key npx @typingmind/mcp <auth-token>
+```
+
+- `CERTFILE`: Path to your SSL certificate file
+- `KEYFILE`: Path to your SSL private key file
+
+When both variables are set, the server will use HTTPS instead of HTTP.
+
 ---
 
 ## How to Run on a Server
@@ -27,6 +39,11 @@ If you prefer running the MCP Connector on a remote server:
 
    ```bash
    npx @typingmind/mcp <auth-token>
+   ```
+
+   To run with HTTPS:
+   ```bash
+   CERTFILE=./path/to/certificate.crt KEYFILE=./path/to/privatekey.key npx @typingmind/mcp <auth-token>
    ```
 
    Alternatively, for persistent running (e.g., after closing SSH), you may use a process manager like [pm2](https://pm2.keymetrics.io/) or `screen`/`tmux`:

--- a/bin/index.js
+++ b/bin/index.js
@@ -15,9 +15,9 @@ if (!authToken) {
 // Start the server with the provided auth token
 server
   .start(authToken)
-  .then(({ host, port }) => {
+  .then(({ host, port, protocol }) => {
     console.log(
-      chalk.green(`✓ MCP runner server running on http://${host}:${port}`),
+      chalk.green(`✓ MCP runner server running on ${protocol}://${host}:${port}`),
     );
     console.log(
       chalk.yellow(
@@ -29,3 +29,4 @@ server
     console.error(chalk.red(`Error starting MCP server: ${err.message}`));
     process.exit(1);
   });
+  

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,8 @@
 const express = require('express');
 const stringify = require('json-stable-stringify');
 const cors = require('cors');
+const fs = require('fs');
+const https = require('https');
 const { findAvailablePort } = require('./port-finder');
 const { authMiddleware } = require('./auth');
 const { Client } = require('@modelcontextprotocol/sdk/client/index.js');
@@ -331,12 +333,39 @@ async function start(authToken) {
     });
   });
 
-  // Start the server
-  return new Promise((resolve) => {
+  // Start the server (HTTP or HTTPS)
+  return new Promise((resolve, reject) => {
     const host = process.env.HOSTNAME || '0.0.0.0';
-    const server = app.listen(port, host, () => {
-      resolve({ port, host });
-    });
+    
+    // Check if certificate and key files are specified
+    const certFile = process.env.CERTFILE;
+    const keyFile = process.env.KEYFILE;
+    
+    let server;
+    
+    if (certFile && keyFile) {
+      try {
+        // Read certificate files
+        const httpsOptions = {
+          cert: fs.readFileSync(certFile),
+          key: fs.readFileSync(keyFile)
+        };
+        
+        // Create HTTPS server
+        server = https.createServer(httpsOptions, app);
+        server.listen(port, host, () => {
+          resolve({ port, host, protocol: 'https' });
+        });
+      } catch (error) {
+        console.error('Error setting up HTTPS server:', error);
+        reject(error);
+      }
+    } else {
+      // Create HTTP server (fallback)
+      server = app.listen(port, host, () => {
+        resolve({ port, host, protocol: 'http' });
+      });
+    }
 
     // Handle graceful shutdown
     process.on('SIGINT', () => {


### PR DESCRIPTION
Enables listening for https connections, addresses #1.

This is necessary to avoid mixed-content errors with Safari when running locally. 

And it allows the server to work when run remotely (where https will be required for any browser due to mixed-content issues), if for some reason it's not configured with a reverse proxy.