### PR TITLE
fix: Avoid Windows reserved port range

### DIFF
--- a/lib/port-finder.js
+++ b/lib/port-finder.js
@@ -1,7 +1,9 @@
 const net = require('net');
 
 // List of ports to try in order
-const PORTS = [50880, 50881];
+const PORTS = [
+  51150, 51151, 51152, 51153, 51154, 51155, 51156, 51157, 51158, 51159,
+];
 
 /**
  * Check if a port is available

--- a/lib/server.js
+++ b/lib/server.js
@@ -75,7 +75,7 @@ async function start(authToken) {
   const port = process.env.PORT || (await findAvailablePort());
   if (!port) {
     throw new Error(
-      'No available ports found. Please ensure one of the following ports is free: 12757, 12758, 12759',
+      'No available ports found. Please ensure one of the following ports is free: 51150 to 51159',
     );
   }
 


### PR DESCRIPTION
The default ports (starting from 50880) fall within a range
often reserved by Windows, particularly when features like Hyper-V
are enabled. This results in 'EACCES: permission denied' errors
when attempting to bind these ports, even when running as
Administrator, as identified by the output of:
`netsh interface ipv4 show excludedportrange protocol=tcp`

This change updates the default port list (PORTS) in lib/port-finder.js
to use the range 51150-51159. This range is within the IANA
dynamic/private ports (49152-65535) and was observed to be outside
the excluded ranges on affected Windows systems.

This resolves the startup failure on such Windows configurations by
using a less conflict-prone port range.