### PR TITLE
Add environment variable substitution for MCP server configurations

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -17,6 +17,28 @@ const {
   getDefaultEnvironment,
 } = require('@modelcontextprotocol/sdk/client/stdio.js');
 
+// Function to recursively replace environment variables
+function replaceEnvVariables(obj) {
+  if (obj === null || typeof obj !== 'object') {
+    return obj;
+  }
+
+  if (Array.isArray(obj)) {
+    return obj.map(replaceEnvVariables);
+  }
+
+  return Object.entries(obj).reduce((acc, [key, value]) => {
+    if (typeof value === 'string') {
+      acc[key] = value.replace(/\$\{env:(\w+)\}/g, (match, envVar) => {
+        return process.env[envVar] || match;
+      });
+    } else {
+      acc[key] = replaceEnvVariables(value);
+    }
+    return acc;
+  }, {});
+}
+
 // Store active MCP clients
 const clients = new Map();
 
@@ -144,8 +166,10 @@ async function start(authToken) {
 
       // Process each server configuration
       const startPromises = Object.entries(mcpServers).map(
-        async ([serverId, config]) => {
+        async ([serverId, originalConfig]) => {
           try {
+            // Replace environment variables in the config
+            const config = replaceEnvVariables(originalConfig);
             // Check if this client already exists
             if (clients.has(serverId)) {
               const hasConfigChanged =


### PR DESCRIPTION
## Problem
Currently, MCP server configurations require literal values for environment variables, which poses security risks when storing API keys in configuration files. This is particularly problematic for services like OpenMemory that require API authentication.

## Solution
This PR adds support for environment variable substitution using `${env:VAR_NAME}` syntax in configuration values.

## Motivating Example
```json
{
  "mcpServers": {
    "openmemory": {
      "command": "npx",
      "args": [
        "-y",
        "openmemory"
      ],
      "env": {
        "OPENMEMORY_API_KEY": "${env:OPENMEMORY_API_KEY}",
        "CLIENT_NAME": "openmemory"
      }
    }
  }
}
```

With this change, the `OPENMEMORY_API_KEY` is read from the environment at runtime, allowing users to:
- Store the actual API key in their shell environment or `.env` file
- Safely commit their MCP configuration to version control
- Share configurations without exposing credentials

## Implementation Details
- Added `replaceEnvVariables()` function that recursively processes configuration objects
- Replaces `${env:VAR_NAME}` patterns with actual environment variable values
- Falls back to original string if environment variable is not found
- Applied before passing configuration to `startClient()`

## Testing
- Tested with OpenMemory MCP server using `${env:OPENMEMORY_API_KEY}`
- Verified that environment variables are correctly substituted
- Confirmed backward compatibility with existing configurations using literal values
- Verified fallback behavior when environment variable is not set

## Security Benefits
- Eliminates need to hardcode sensitive API keys in configuration files
- Enables safe version control of MCP configurations
- Supports different credentials for different environments (dev/staging/prod)

## Backward Compatibility
This change is fully backward compatible. Existing configurations with literal values continue to work as before.