### PR TITLE
Fix: clear stale client entry on failed restart in /start

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -61,7 +61,7 @@ const createRemoteClient = async ({ clientId, url, headers }) => {
 };
 
 // Helper function to start a client with given configuration
-async function startClient(clientId, config) {
+async function createClientEntry(clientId, config) {
   const { command, url, args = [], env = {}, headers } = config;
 
   if (!command && !url) {
@@ -103,8 +103,7 @@ async function startClient(clientId, config) {
     throw new Error('Either command or url must be provided');
   }
 
-  // Store the client with its ID
-  clients.set(clientId, {
+  return {
     id: clientId,
     client,
     command,
@@ -112,7 +111,15 @@ async function startClient(clientId, config) {
     env,
     config, // Store original config for restart
     createdAt: new Date(),
-  });
+  };
+}
+
+// Helper function to start a client with given configuration
+async function startClient(clientId, config) {
+  const clientEntry = await createClientEntry(clientId, config);
+
+  // Store the client with its ID
+  clients.set(clientId, clientEntry);
 
   return {
     id: clientId,
@@ -168,17 +175,34 @@ async function start(authToken) {
           try {
             // Check if this client already exists
             if (clients.has(serverId)) {
+              const existingClient = clients.get(serverId);
               const hasConfigChanged =
-                stringify(clients.get(serverId).config) !== stringify(config);
+                stringify(existingClient.config) !== stringify(config);
               if (!hasConfigChanged) {
                 return;
               }
               console.log('Restarting client with new config:', serverId);
-              clients.get(serverId).client.close();
+              const replacementClient = await createClientEntry(
+                serverId,
+                config,
+              );
+              clients.set(serverId, replacementClient);
+              existingClient.client.close().catch((error) => {
+                console.error(
+                  `Error closing existing client ${serverId} during restart:`,
+                  error,
+                );
+              });
+            } else {
+              const result = await startClient(serverId, config);
+              results.success.push(result);
+              return;
             }
 
-            const result = await startClient(serverId, config);
-            results.success.push(result);
+            results.success.push({
+              id: serverId,
+              message: 'MCP client started successfully',
+            });
           } catch (error) {
             console.error(`Failed to initialize client ${serverId}:`, error);
             results.errors.push({
@@ -228,16 +252,22 @@ async function start(authToken) {
         env: clientEntry.env,
       };
 
-      // Close the existing client
-      await clientEntry.client.close();
-      clients.delete(id);
+      const replacementClient = await createClientEntry(id, config);
+      clients.set(id, replacementClient);
 
-      // Start a new client with the same configuration
-      const result = await startClient(id, config);
+      clientEntry.client.close().catch((error) => {
+        console.error(
+          `Error closing existing client ${id} during restart:`,
+          error,
+        );
+      });
 
       return res.status(200).json({
         message: `Client ${id} restarted successfully`,
-        client: result,
+        client: {
+          id,
+          message: 'MCP client started successfully',
+        },
       });
     } catch (error) {
       console.error(`Error restarting client ${id}:`, error);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@typingmind/mcp",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "repository": "https://github.com/TypingMind/typingmind-mcp",
   "description": "Model Context Protocol (MCP) servers runner for TypingMind",
   "main": "lib/server.js",


### PR DESCRIPTION
Issue:

- Call /start with correct config → client stored with correctConfig
- Call /start with wrong config → old client is closed but NOT removed from clients map, then startClient throws → the map still holds the old (now dead) entry with correctConfig
- Call /start with correct config → finds entry, config matches → skips restart → returns without error, but the underlying client connection is closed/dead