### PR TITLE
Enhance MCP server configuration: add MCP_URL_ONLY environment variable to restrict to URL-based clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,19 @@ npx @typingmind/mcp@latest <auth-token>
 
 ---
 
+## Restricting to URL-based MCPs
+
+By default, MCP Connector can start MCP servers via either a local `command` (stdio transport) or a remote `url`. The stdio path spawns arbitrary local processes on the host — useful, but it means any caller who can present a valid auth token is effectively able to execute commands on the machine running the connector.
+
+If your deployment only needs to proxy remote MCP servers, you can disable the stdio path entirely by setting the `MCP_URL_ONLY` environment variable to a truthy value (`1`, `true`, or `yes`, case-insensitive). When set, any `/start` or `/restart/:id` request whose config contains a `command` field will be rejected, and only `url`-based MCP clients will be accepted.
+
+```bash
+# Only allow URL-based (remote) MCP servers
+MCP_URL_ONLY=true npx @typingmind/mcp@latest <auth-token>
+```
+
+---
+
 ## REST API Endpoints
 
 All API endpoints require authentication via the Bearer token you provide when starting the server.

--- a/lib/server.js
+++ b/lib/server.js
@@ -68,6 +68,13 @@ async function createClientEntry(clientId, config) {
     throw new Error('command or url is required');
   }
 
+  const urlOnly = /^(1|true|yes)$/i.test(process.env.MCP_URL_ONLY || '');
+  if (urlOnly && command) {
+    throw new Error(
+      'Stdio (command) MCP clients are disabled: MCP_URL_ONLY is set. Provide a "url" instead.',
+    );
+  }
+
   let client;
 
   if (command) {


### PR DESCRIPTION
  ## Summary

  - `createClientEntry` in `lib/server.js` can spawn arbitrary local processes via the stdio `command` path, giving any authenticated caller effective RCE on the host.
  - Added new opt-in env var `MCP_URL_ONLY`: when truthy, configs with `command` are rejected and only `url`-based MCP clients are accepted. So only known proxies/URL servers can be used.
  - Default behavior unchanged when the var is unset. 